### PR TITLE
use clap to handle args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,157 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "clap"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "regex"
@@ -35,8 +182,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
 name = "treefetch"
 version = "2.0.0"
 dependencies = [
+ "clap",
  "regex",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 regex = "1"
+clap = {version = "3.0", features = ["derive", "cargo"]}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🌳 `treefetch`
+# 🌲 `treefetch`
 
-A lightning-fast minimalist system fetch tool made in Rust. Even faster than neofetch and pfetch. Made to practice my new Rust skills 🦀.
+A comfy and fast system fetch tool made in Rust. Tested to be much faster than neofetch and pfetch.
 
 A great pair for [cbonsai](https://gitlab.com/jallbrit/cbonsai), to help you get upvotes on your Linux rice.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,92 +1,82 @@
-use std::env;
-use std::process;
+use clap::{app_from_crate, arg};
 mod colors;
 mod fields;
 
 // Simple system fetch tool written in Rust.
 fn main() {
+    let matches = app_from_crate!()
+        .arg(arg!([TREE])
+            .help("Which tree to display.")
+            .possible_values(["normal", "xmas", "bonsai"])
+            .default_value("normal"))
+        .get_matches();
 
-    let args: Vec<String> = env::args().collect();
     let mut is_christmas = false;
-    let mut ascii_tree: String;
+    let ascii_tree: String;
 
-    ascii_tree = format!(
-        "{green}     /\\*\\       {reset}
-        {green}    /\\O\\*\\      {reset}
-        {green}   /*/\\/\\/\\     {reset}
-        {green}  /\\O\\/\\*\\/\\    {reset}
-        {green} /\\*\\/\\*\\/\\/\\   {reset}
-        {green} |O\\/\\/*/\\/O|   {reset}
-        {yellow}      ||        {reset}
-        {yellow}      ||        {reset}
-        ",
-        green = colors::green,
-        yellow = colors::yellow,
-        reset = colors::reset,
-    );
-
-    // Skip first arg as that is the program command
-    for arg in &args[1..] {
-
-        // Convert to string slice for the comparisons
-        let arg = &arg[..];
-
-        match arg {
-            "--help" | "-h" => {
-                help_message()
-            }
-
-            "--bonsai" | "-b" => {
-                ascii_tree = format!(
-                    "{green} {bold}             &               {reset}
-                    {green}          && & &&             {reset}
-                    {green}         &{yellow}_& & _/{green}&            {reset}
-                    {yellow}{bold}           /~\\                {reset}
-                    {green} &  & &{yellow}     /|                {reset}
-                    {green} & {yellow}{bold}_&{reset}{green}&{yellow}   _\\_/|   {green}             {reset}
-                    {green}&& {yellow}{bold}&{reset}{green}&&{yellow}_/    |\\     {green} && &      {reset}
-                    {green}  &&{yellow}_|/{green}{bold} &{reset}{yellow}  \\//~\\{green}{bold}   &&{reset}{yellow} &&{green}&  {reset}
-                    {yellow}            |/\\__/{green}& &{yellow}_/_{green}&&  {reset}
-                    {gray}        {bold}:{reset}{green}____{yellow}./~\\.{green}____{gray}{bold}:         {reset}
-                    {gray}{bold}         \\___________/         {reset}
-                    {gray}{bold}          (_)     (_)            {reset}
-                    ",
-                    gray = colors::gray,
-                    green = colors::green,
-                    yellow = colors::yellow,
-                    reset = colors::reset,
-                    bold = colors::bold,
-                );
-                break;
-            }
-
-            "--xmas" | "-x" => {
-                ascii_tree = format!(
-                    "{bright_yellow}{bold}      ★         {reset}
-                    {green}     /\\{red}{bold}o{green}\\       {reset}
-                    {green}    /\\{red}{bold}o{green}\\*\\      {reset}
-                    {green}   /{red}{bold}o{green}/\\/\\{blue}{bold}o{green}\\     {reset}
-                    {green}  /\\O\\/\\{red}{bold}o{green}\\/{red}{bold}o{green}    {reset}
-                    {green} /{blue}{bold}o{green}*{red}{bold}o{green}/{blue}{bold}o{green}*\\/{red}{bold}o{green}/\\   {reset}
-                    {green} |O\\/\\/*/{red}{bold}o{green}/O|   {reset}
-                    {yellow}      ||        {reset}
-                    ",
-                    red = colors::red,
-                    green = colors::green,
-                    blue = colors::blue,
-                    yellow = colors::yellow,
-                    bright_yellow = "\x1b[93m",
-                    bold = colors::bold,
-                    reset = colors::reset,
-                );
-                is_christmas = true;
-                break;
-            }
-
-            _ => {
-                invalid_option(arg.to_string());
-            }
+    match matches.value_of("TREE").unwrap() {
+        "normal" => {
+            ascii_tree = format!(
+                "{green}     /\\*\\       {reset}
+            {green}    /\\O\\*\\      {reset}
+            {green}   /*/\\/\\/\\     {reset}
+            {green}  /\\O\\/\\*\\/\\    {reset}
+            {green} /\\*\\/\\*\\/\\/\\   {reset}
+            {green} |O\\/\\/*/\\/O|   {reset}
+            {yellow}      ||        {reset}
+            {yellow}      ||        {reset}
+            ",
+                green = colors::green,
+                yellow = colors::yellow,
+                reset = colors::reset,
+            );
         }
+        "bonsai" => {
+            ascii_tree = format!(
+                "{green} {bold}             &               {reset}
+                {green}          && & &&             {reset}
+                {green}         &{yellow}_& & _/{green}&            {reset}
+                {yellow}{bold}           /~\\                {reset}
+                {green} &  & &{yellow}     /|                {reset}
+                {green} & {yellow}{bold}_&{reset}{green}&{yellow}   _\\_/|   {green}             {reset}
+                {green}&& {yellow}{bold}&{reset}{green}&&{yellow}_/    |\\     {green} && &      {reset}
+                {green}  &&{yellow}_|/{green}{bold} &{reset}{yellow}  \\//~\\{green}{bold}   &&{reset}{yellow} &&{green}&  {reset}
+                {yellow}            |/\\__/{green}& &{yellow}_/_{green}&&  {reset}
+                {gray}        {bold}:{reset}{green}____{yellow}./~\\.{green}____{gray}{bold}:         {reset}
+                {gray}{bold}         \\___________/         {reset}
+                {gray}{bold}          (_)     (_)            {reset}
+                ",
+                gray = colors::gray,
+                green = colors::green,
+                yellow = colors::yellow,
+                reset = colors::reset,
+                bold = colors::bold,
+            );
+        }
+
+        "xmas" => {
+            ascii_tree = format!(
+                "{bright_yellow}{bold}      ★         {reset}
+                {green}     /\\{red}{bold}o{green}\\       {reset}
+                {green}    /\\{red}{bold}o{green}\\*\\      {reset}
+                {green}   /{red}{bold}o{green}/\\/\\{blue}{bold}o{green}\\     {reset}
+                {green}  /\\O\\/\\{red}{bold}o{green}\\/{red}{bold}o{green}    {reset}
+                {green} /{blue}{bold}o{green}*{red}{bold}o{green}/{blue}{bold}o{green}*\\/{red}{bold}o{green}/\\   {reset}
+                {green} |O\\/\\/*/{red}{bold}o{green}/O|   {reset}
+                {yellow}      ||        {reset}
+                ",
+                red = colors::red,
+                green = colors::green,
+                blue = colors::blue,
+                yellow = colors::yellow,
+                bright_yellow = "\x1b[93m",
+                bold = colors::bold,
+                reset = colors::reset,
+            );
+            is_christmas = true;
+        }
+
+        _ => unreachable!()
     }
 
     let ascii_tree = split_by_newline(ascii_tree);
@@ -94,10 +84,9 @@ fn main() {
     let mut data_list: Vec<String> = Vec::new();
 
     if let Ok(value) = fields::get_user_host_name(is_christmas) {
-            data_list.push(value.0);
-            data_list.push(value.1);
+        data_list.push(value.0);
+        data_list.push(value.1);
     };
-
 
     if let Ok(value) = fields::get_distro_name() {
         data_list.push(value);
@@ -131,25 +120,26 @@ fn main() {
 }
 
 // Print two vectors of strings side to side
-fn print_left_to_right(left: Vec<String>, right: Vec<String>,
-                       is_christmas: bool) {
+fn print_left_to_right(left: Vec<String>, right: Vec<String>, is_christmas: bool) {
     let left_len = left.len();
     let right_len = right.len();
-    let max_len = if left_len > right_len {left_len} else {right_len};
+    let max_len = if left_len > right_len {
+        left_len
+    } else {
+        right_len
+    };
 
     for i in 0..max_len {
         if i < left_len {
             print!("{}", left[i]);
         }
         if i < right_len {
-
             // Red square if Christmas mode
             if is_christmas {
-                print!("{}", right[i]
-                       .replace("▪",
-                                &format!("{}▪{}",
-                                         colors::red,
-                                         colors::green)));
+                print!(
+                    "{}",
+                    right[i].replace("▪", &format!("{}▪{}", colors::red, colors::green))
+                );
             } else {
                 print!("{}", right[i]);
             }
@@ -175,29 +165,4 @@ fn split_by_newline(ascii_art: String) -> Vec<String> {
     }
 
     split
-}
-
-fn help_message() {
-    let version = env!("CARGO_PKG_VERSION");
-    println!("Usage:");
-    println!("  {bold}{green}treefetch{reset} [options]",
-            green = colors::green,
-            reset = colors::reset,
-            bold = colors::bold,
-            );
-    println!();
-    println!("OPTIONS");
-    println!("  -b, --bonsai   Show a bonsai tree");
-    println!("  -x, --xmas     Show a Christmas tree");
-    println!("  -h, --help     Display this help message");
-    println!();
-    println!("treefetch {}", version);
-    println!("Report bugs to https://github.com/angelofallars/treefetch/issues");
-    process::exit(1)
-}
-
-fn invalid_option(option: String) {
-    println!("Unrecognized option '{}'", option);
-    println!("Try 'treefetch --help' for more information.");
-    process::exit(1)
 }


### PR DESCRIPTION
Use the crate [clap](https://crates.io/crates/clap) to handle arguments.
Now the help message is like:
```
treefetch 2.0.0

USAGE:
    treefetch [TREE]

ARGS:
    <TREE>    Which tree to display. [default: normal] [possible values: normal, xmas, bonsai]

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information
```