### PR TITLE
improve code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A great pair for [cbonsai](https://gitlab.com/jallbrit/cbonsai), to help you get
 
 <img src="https://user-images.githubusercontent.com/39676098/145780007-f612ceff-7414-4bbe-af14-e2d48004ed9d.png" alt="treefetch" width=380px>
 
-More trees with `treefetch --bonsai` and `treefetch --xmas`!
+More trees with `treefetch bonsai` and `treefetch xmas`!
 
 <img src="https://user-images.githubusercontent.com/39676098/149612115-2a02d617-d70a-4eed-bcce-2dd590698ea1.png" alt="treefetch bonus trees" width=380px>
 
@@ -44,13 +44,15 @@ program anywhere.
 ## Usage
 
 ```
-Usage:
-  treefetch [options]
+USAGE:
+    treefetch [TREE]
 
-OPTIONS
-  -b, --bonsai   Show a bonsai tree
-  -x, --xmas     Show a Christmas tree
-  -h, --help     Display this help message
+ARGS:
+    <TREE>    Which tree to display. [default: normal] [possible values: normal, xmas, bonsai]
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
 ```
 
 ## Contributing

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -2,6 +2,7 @@ pub mod codes {
     pub const _RED: &str = "\x1b[31m";
     pub const _GREEN: &str = "\x1b[32m";
     pub const _YELLOW: &str = "\x1b[33m";
+    pub const _BRIGHT_YELLOW: &str = "\x1b[93m";
     pub const _BLUE: &str = "\x1b[34m";
     pub const _CYAN: &str = "\x1b[36m";
     pub const _GRAY: &str = "\x1b[38;5;8m";
@@ -13,6 +14,7 @@ pub mod codes {
 pub use self::codes::_RED as red;
 pub use self::codes::_GREEN as green;
 pub use self::codes::_YELLOW as yellow;
+pub use self::codes::_BRIGHT_YELLOW as bright_yellow;
 pub use self::codes::_BLUE as blue;
 pub use self::codes::_CYAN as cyan;
 pub use self::codes::_MAGENTA as magenta;


### PR DESCRIPTION
## Changes  
* Created a macro to simplify the code;  
* Replaced `print_left_to_right()` with something more concise (based on the fact that every tree is 'taller' than the right side);  
* Modified `README.md` (options => arguments). Also please consider changing the example images;

## Suggestions
* Rewrite `fields.rs` using third-party crates (e.g. [nixinfo](https://crates.io/crates/nixinfo)) so that we can support more systems and at the same time simplify the code ;
_(It's OK not to do so as maybe you are practicing Rust through this project, which is exactly what I'm doing :P);_
* Try using [copilot](https://github.com/github/copilot.vim), [RustFmt](https://github.com/rust-lang/rustfmt) in neovim. These will certainly increase the efficiency.