### PR TITLE
Use systemstat and nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -54,10 +72,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nom"
@@ -124,6 +164,7 @@ dependencies = [
 name = "treefetch"
 version = "2.0.0"
 dependencies = [
+ "nix",
  "regex",
  "systemstat",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "regex"
@@ -35,8 +107,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "systemstat"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8862adb0fd5f4c5707b0eeb6c2ec7610bd7a8bf5e069150bd6dde04a7f40ebf7"
+dependencies = [
+ "bytesize",
+ "chrono",
+ "lazy_static",
+ "libc",
+ "nom",
+ "winapi",
+]
+
+[[package]]
 name = "treefetch"
 version = "2.0.0"
 dependencies = [
  "regex",
+ "systemstat",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 regex = "1"
 systemstat = "0.1"
+nix = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 regex = "1"
+systemstat = "0.1"

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -143,11 +143,15 @@ pub fn get_distro_name() -> Result<String, String> {
     Err("error".to_string())
 }
 
-pub fn get_kernel() -> Result<String, String> {
+pub fn get_kernel(show_kern_name: bool) -> Result<String, String> {
     let uname = nix::sys::utsname::uname();
     Ok(format_data(
         "kernel",
-        &format!("{} {}", uname.release(), uname.machine())))
+        &if show_kern_name {
+            format!("{}/{} {}", uname.sysname(), uname.machine(), uname.release())
+        } else {
+            format!("{} {}", uname.release(), uname.machine())
+        }))
 }
 
 pub fn get_shell() -> Result<String, String> {

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -208,124 +208,24 @@ pub fn get_shell() -> Result<String, String> {
     Ok(format_data("shell", shell))
 }
 
-pub fn get_uptime() -> Result<String, String> {
-    // Get the uptime file
-    let uptime_file = fs::File::open("/proc/uptime");
-
-    // Return if can't find it
-    if uptime_file.is_err() {
-        return Err("Error".to_string());
-    }
-
-    let mut uptime_file = uptime_file.unwrap();
-    let mut uptime = String::new();
-
-    let result = uptime_file.read_to_string(&mut uptime);
-
-    if result.is_err() {
-        return Err("error".to_string());
-    }
-
-    let re_uptime = match_regex(&uptime,
-                                r#"(?x)
-                                ^(?P<uptime_seconds>\d+)\.
-                                "#.to_string());
-
-    if re_uptime.is_none() {
-        return Err("error".to_string());
-    }
-
-    let re_uptime = re_uptime.unwrap();
-
-    // Parse the uptime in seconds into an integer
-    let uptime_seconds: u32 = re_uptime
-        .name("uptime_seconds")
-        .unwrap()
-        .as_str()
-        .parse()
-        .unwrap();
+pub fn format_uptime(time: std::time::Duration) -> String {
+    let uptime_seconds = time.as_secs();
 
     // Calculate the uptime in hours and minutes respectively
-    let uptime_hours: u32 = uptime_seconds / (60 * 60);
-    let uptime_minutes: u32 = (uptime_seconds % (60 * 60)) / 60;
+    let uptime_hours = uptime_seconds / (60 * 60);
+    let uptime_minutes = (uptime_seconds % (60 * 60)) / 60;
 
-    return Ok(format_data(
-            "uptime",
-            &format!("{hours}h {minutes}m",
-                     hours = uptime_hours,
-                     minutes = uptime_minutes)
-            ));
+    format_data(
+        "uptime",
+        &format!("{hours}h {minutes}m",
+                 hours = uptime_hours,
+                 minutes = uptime_minutes))
 }
 
-pub fn get_memory() -> Result<String, String> {
-    // Get the memory file
-    let memory_file = fs::File::open("/proc/meminfo");
-
-    // Return if can't find it
-    if memory_file.is_err() {
-        return Err("Error".to_string());
-    }
-
-    let mut memory_file = memory_file.unwrap();
-    let mut memory = String::new();
-
-    let result = memory_file.read_to_string(&mut memory);
-
-    if result.is_err() {
-        return Err("error".to_string());
-    }
-
-    let re_total_memory = match_regex(&memory,
-                                      r#"(?x)
-                                      MemTotal:
-                                      \s+
-                                      (?P<mem_total>\d+)
-                                      .+\n.+\n
-                                      MemAvailable:
-                                      "#.to_string());
-
-    if re_total_memory.is_none() {
-        return Err("error".to_string());
-    }
-
-    let re_available_memory = match_regex(&memory,
-                                          r#"(?x)
-                                          MemAvailable:
-                                          \s+
-                                          (?P<mem_available>\d+)
-                                          "#.to_string());
-
-    if re_available_memory.is_none() {
-        return Err("error".to_string());
-    }
-
-    let re_total_memory = re_total_memory.unwrap();
-    let re_available_memory = re_available_memory.unwrap();
-
-    let total_mem: i32 = re_total_memory
-                         .name("mem_total")
-                         .unwrap()
-                         .as_str()
-                         .parse()
-                         .unwrap();
-
-    let available_mem: i32 = re_available_memory
-                             .name("mem_available")
-                             .unwrap()
-                             .as_str()
-                             .parse()
-                             .unwrap();
-
-    let used_mem = total_mem - available_mem;
-
-    // Divide memory by 1,000
-    let total_mem = total_mem / 1_024;
-    let used_mem = used_mem / 1_024;
-
-    return Ok(format_data(
-              "memory",
-              &format!("{used}m / {total}m",
-                       used = used_mem,
-                       total = total_mem)
-            ));
+pub fn format_memory(mem: systemstat::Memory) -> String {
+    format_data(
+        "memory",
+        &format!("{used} / {total}",
+                 used = systemstat::saturating_sub_bytes(mem.total, mem.free),
+                 total = mem.total))
 }

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -229,3 +229,12 @@ pub fn format_memory(mem: systemstat::Memory) -> String {
                  used = systemstat::saturating_sub_bytes(mem.total, mem.free),
                  total = mem.total))
 }
+
+pub fn format_battery(battery: systemstat::BatteryLife) -> String {
+    format_data(
+        "battery",
+        &format!("{percent}%, {hours}h {minutes}m remaining",
+                 percent = battery.remaining_capacity * 100.0,
+                 hours = battery.remaining_time.as_secs() / 3600,
+                 minutes = battery.remaining_time.as_secs() % 60))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,12 @@ fn main() {
         data_list.push(fields::format_memory(value));
     };
 
+    // Battery
+
+    if let Ok(value) = stat.battery_life() {
+        data_list.push(fields::format_battery(value));
+    };
+
     print_left_to_right(ascii_tree, data_list, is_christmas);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::process;
+use systemstat::Platform;
 mod colors;
 mod fields;
 
@@ -91,6 +92,8 @@ fn main() {
 
     let ascii_tree = split_by_newline(ascii_tree);
 
+    let stat = systemstat::System::new();
+
     let mut data_list: Vec<String> = Vec::new();
 
     if let Ok(value) = fields::get_user_host_name(is_christmas) {
@@ -117,14 +120,14 @@ fn main() {
 
     // Uptime
 
-    if let Ok(value) = fields::get_uptime() {
-        data_list.push(value);
+    if let Ok(value) = stat.uptime() {
+        data_list.push(fields::format_uptime(value));
     };
 
     // Memory
 
-    if let Ok(value) = fields::get_memory() {
-        data_list.push(value);
+    if let Ok(value) = stat.memory() {
+        data_list.push(fields::format_memory(value));
     };
 
     print_left_to_right(ascii_tree, data_list, is_christmas);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod fields;
 fn main() {
 
     let args: Vec<String> = env::args().collect();
+    let mut show_kern_name = false;
     let mut is_christmas = false;
     let mut ascii_tree: String;
 
@@ -84,6 +85,10 @@ fn main() {
                 break;
             }
 
+            "--kernel-name" | "-k" => {
+                show_kern_name = true;
+            }
+
             _ => {
                 invalid_option(arg.to_string());
             }
@@ -108,7 +113,7 @@ fn main() {
 
     // Kernel name
 
-    if let Ok(value) = fields::get_kernel() {
+    if let Ok(value) = fields::get_kernel(show_kern_name) {
         data_list.push(value);
     };
 


### PR DESCRIPTION
This significantly improves portability (#8):

![Screen_2022-02-13-23:48:41](https://user-images.githubusercontent.com/208340/153774431-4827a46e-8c35-4189-a44a-878ae83dbd3c.png)
